### PR TITLE
Started work on account accumulations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 .env
 
 subgraph.yaml
+docker-compose.yaml
+data/
 test/data/*.json
 abis/combined/*.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .env
 
 subgraph.yaml
-docker-compose.yaml
+docker-compose.yml
 data/
 test/data/*.json
 abis/combined/*.json

--- a/schema.graphql
+++ b/schema.graphql
@@ -65,8 +65,7 @@ type MarketAccount @entity {
   latestOrderId: BigInt! # Latest account order id
   currentOrderId: BigInt! # Current account order id
   collateral: BigInt! # Current account collateral
-  # TODO: implement
-  # accumulators: [MarketAccountAccumulation!]! @derivedFrom(field: "marketAccount") # Accumulates data for market and account across positions
+  accumulators: [AccountAccumulator!]! @derivedFrom(field: "marketAccount") # Accumulates data for market and account across positions
 }
 
 type Position @entity {
@@ -153,7 +152,7 @@ type SubOracle @entity {
   versions: [OracleVersion!]! @derivedFrom(field: "subOracle") # Oracle versions for this sub oracle
 }
 
-# Tracking value to provide pnl breakdowns. This is a cummulative value that is updated on each oracle version. To find the pnl for a given time period, subtract the previous version's value from the current version's value and multiply by the position.
+# Tracking value to provide pnl breakdowns. This is a cumulative value that is updated on each oracle version. To find the pnl for a given time period, subtract the previous version's value from the current version's value and multiply by the position.
 type MarketAccumulator @entity(immutable: true) {
   id: Bytes! # market:version
   market: Market! # Parent Market
@@ -238,8 +237,19 @@ type MarketAccumulation @entity {
   interestRateShort: BigInt!
 }
 
+
+# Tracking value to provide pnl breakdowns. This is a cumulative value that is updated on each oracle version. To find the pnl for a given time period, subtract the previous version's value from the current version's value and multiply by the position.
+type AccountAccumulator @entity(immutable: true) {
+  id: Bytes! # market:version
+  marketAccount: MarketAccount! # Parent MarketAccount
+  fromVersion: BigInt! # Oracle version timestamp
+  toVersion: BigInt! # Oracle version timestamp
+  # TODO: determine accumulators to add here
+  collateral: BigInt!
+}
+
 # TODO: Accumulation data for a MarketAccount, bucketed by time
-type AccountNewAccumulation @entity {
+type AccountAccumulation @entity {
   id: Bytes! # market:version
   market: Market! # Parent Market
   account: Account! # Parent Account
@@ -247,6 +257,7 @@ type AccountNewAccumulation @entity {
   bucket: Bucket! # Bucket for this accumulation
   timestamp: BigInt! # Oracle version timestamp
   # TODO: determine metrics to add here
+  collateral: BigInt!
 }
 
 type MultiInvokerTriggerOrder @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -261,6 +261,12 @@ type MarketAccountAccumulation @entity {
   timestamp: BigInt! # Oracle version timestamp
   collateral: BigInt!
   fees: BigInt!
+  maker: BigInt! # Latest maker position in bucket
+  long: BigInt! # Latest long position in bucket
+  short: BigInt! # Latest short position in bucket
+  makerNotional: BigInt! # Notional value of maker position
+  longNotional: BigInt! # Notional value of long position
+  shortNotional: BigInt! # Notional value of short position
   trades: BigInt! # Number of orders which increased the account's position
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -244,8 +244,8 @@ type MarketAccountAccumulator @entity(immutable: true) {
   marketAccount: MarketAccount! # Parent MarketAccount
   fromVersion: BigInt! # Oracle version timestamp
   toVersion: BigInt! # Oracle version timestamp
-  # TODO: determine accumulators to add here
   collateral: BigInt!
+  fees: BigInt!
 }
 
 # TODO: Accumulation data for a MarketAccount, bucketed by time
@@ -256,8 +256,8 @@ type MarketAccountAccumulation @entity {
   marketAccount: MarketAccount! # Parent MarketAccount
   bucket: Bucket! # Bucket for this accumulation
   timestamp: BigInt! # Oracle version timestamp
-  # TODO: determine metrics to add here
-  collateral: BigInt!
+  collateral: BigInt! # Collateral accumulated in market
+  fees: BigInt! # Fees accumulated in market
 }
 
 type MultiInvokerTriggerOrder @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -235,6 +235,9 @@ type MarketAccumulation @entity {
   interestRateMaker: BigInt!
   interestRateLong: BigInt!
   interestRateShort: BigInt!
+  #
+  trades: BigInt! # Number of orders which increased an account's position
+  traders: BigInt! # Number of accounts which increased their position
 }
 
 
@@ -244,11 +247,11 @@ type MarketAccountAccumulator @entity(immutable: true) {
   marketAccount: MarketAccount! # Parent MarketAccount
   fromVersion: BigInt! # Oracle version timestamp
   toVersion: BigInt! # Oracle version timestamp
-  collateral: BigInt!
-  fees: BigInt!
+  collateral: BigInt! # Collateral accumulated
+  fees: BigInt! # Fees accumulated
 }
 
-# TODO: Accumulation data for a MarketAccount, bucketed by time
+# Accumulation data for a MarketAccount, bucketed by time
 type MarketAccountAccumulation @entity {
   id: Bytes! # market:version
   market: Market! # Parent Market
@@ -256,8 +259,9 @@ type MarketAccountAccumulation @entity {
   marketAccount: MarketAccount! # Parent MarketAccount
   bucket: Bucket! # Bucket for this accumulation
   timestamp: BigInt! # Oracle version timestamp
-  collateral: BigInt! # Collateral accumulated in market
-  fees: BigInt! # Fees accumulated in market
+  collateral: BigInt!
+  fees: BigInt!
+  trades: BigInt! # Number of orders which increased the account's position
 }
 
 type MultiInvokerTriggerOrder @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -236,8 +236,8 @@ type MarketAccumulation @entity {
   interestRateLong: BigInt!
   interestRateShort: BigInt!
   #
-  trades: BigInt! # Number of orders which increased an account's position
-  traders: BigInt! # Number of accounts which increased their position
+  trades: BigInt! # Number of orders which changed an account's position
+  traders: BigInt! # Number of accounts which changed their position
 }
 
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -105,7 +105,8 @@ type Order @entity {
   orderId: BigInt! # Account order id
   marketOrder: MarketOrder! # Parent MarketOrder
   oracleVersion: OracleVersion! # Order oracle version
-  startCollateral: BigInt! # Collateral at the time of transaction
+  startCollateral: BigInt! # Collateral before transaction
+  endCollateral: BigInt! # Collateral after transaction
   #
   liquidation: Boolean! # If this order is a liquidation
   referrer: Bytes! # Referrer account

--- a/schema.graphql
+++ b/schema.graphql
@@ -65,7 +65,7 @@ type MarketAccount @entity {
   latestOrderId: BigInt! # Latest account order id
   currentOrderId: BigInt! # Current account order id
   collateral: BigInt! # Current account collateral
-  accumulators: [AccountAccumulator!]! @derivedFrom(field: "marketAccount") # Accumulates data for market and account across positions
+  accumulators: [MarketAccountAccumulator!]! @derivedFrom(field: "marketAccount") # Accumulates data for market and account across positions
 }
 
 type Position @entity {
@@ -93,7 +93,7 @@ type Position @entity {
   notional: BigInt! # Total notional volume for this position
   netDeposits: BigInt! # Total deposits for this position
   #
-  accumulation: MarketAccountAccumulation! # Accumulation for this position
+  accumulation: OrderAccumulation! # Accumulation for this position
 }
 
 type Order @entity {
@@ -120,7 +120,7 @@ type Order @entity {
   newLong: BigInt! # Position long size after settlement. Optimistically updated on Fulfillment if requested
   newShort: BigInt! # Position short size after settlement. Optimistically updated on Fulfillment if requested
   #
-  accumulation: MarketAccountAccumulation! # Accumulation for this order
+  accumulation: OrderAccumulation! # Accumulation for this order
   #
   transactionHashes: [Bytes!]! # Transaction hashes for this order's creation
 }
@@ -179,7 +179,7 @@ type MarketAccumulator @entity(immutable: true) {
 }
 
 # Accumulation data for an account order or position.
-type MarketAccountAccumulation @entity {
+type OrderAccumulation @entity {
   id: Bytes! # determined by creator
   collateral_accumulation: BigInt! # Total collateral accumulated for the parent entity - summation of collateral_subAccumulation_*
   fee_accumulation: BigInt! # Total fees accumulated for the parent entity - summation of fee_subAccumulation_*
@@ -239,7 +239,7 @@ type MarketAccumulation @entity {
 
 
 # Tracking value to provide pnl breakdowns. This is a cumulative value that is updated on each oracle version. To find the pnl for a given time period, subtract the previous version's value from the current version's value and multiply by the position.
-type AccountAccumulator @entity(immutable: true) {
+type MarketAccountAccumulator @entity(immutable: true) {
   id: Bytes! # market:version
   marketAccount: MarketAccount! # Parent MarketAccount
   fromVersion: BigInt! # Oracle version timestamp
@@ -249,7 +249,7 @@ type AccountAccumulator @entity(immutable: true) {
 }
 
 # TODO: Accumulation data for a MarketAccount, bucketed by time
-type AccountAccumulation @entity {
+type MarketAccountAccumulation @entity {
   id: Bytes! # market:version
   market: Market! # Parent Market
   account: Account! # Parent Account

--- a/schema.graphql
+++ b/schema.graphql
@@ -101,6 +101,7 @@ type Order @entity {
   position: Position! # Parent Position
   account: Account! # Account address (needed to query by account as position.marketAccount.account is not supported)
   market: Market! # Market address (needed to query by market as position.marketAccount.account is not supported)
+  timestamp: BigInt! # Oracle version timestamp
   orderId: BigInt! # Account order id
   marketOrder: MarketOrder! # Parent MarketOrder
   oracleVersion: OracleVersion! # Order oracle version

--- a/schema.graphql
+++ b/schema.graphql
@@ -21,7 +21,7 @@ type Market @entity {
 }
 
 type MarketOrder @entity {
-  id: Bytes! # markeetAddress:orderId
+  id: Bytes! # marketAddress:orderId
   market: Market! # Market address
   orderId: BigInt! # Global order id
   version: BigInt! # Oracle version timestamp
@@ -44,7 +44,7 @@ type Account @entity {
 }
 
 type MarketAccount @entity {
-  id: Bytes! # markeetAddress:accountAddress
+  id: Bytes! # marketAddress:accountAddress
   market: Market! # Parent Market
   account: Account! # Parent Account
   positions: [Position!]! @derivedFrom(field: "marketAccount") # Positions in this market account. A position is defined by going from zero to non-zero and back to zero.
@@ -65,10 +65,12 @@ type MarketAccount @entity {
   latestOrderId: BigInt! # Latest account order id
   currentOrderId: BigInt! # Current account order id
   collateral: BigInt! # Current account collateral
+  # TODO: implement
+  # accumulators: [MarketAccountAccumulation!]! @derivedFrom(field: "marketAccount") # Accumulates data for market and account across positions
 }
 
 type Position @entity {
-  id: Bytes! # markeetAddress:accountAddress:positionNonce
+  id: Bytes! # marketAddress:accountAddress:positionNonce
   marketAccount: MarketAccount! # Parent MarketAccount
   orders: [Order!]! @derivedFrom(field: "position") # Orders for this position
   nonce: BigInt! # Unique ID for this position
@@ -92,11 +94,11 @@ type Position @entity {
   notional: BigInt! # Total notional volume for this position
   netDeposits: BigInt! # Total deposits for this position
   #
-  accumulation: AccountAccumulation! # Accumulation for this position
+  accumulation: MarketAccountAccumulation! # Accumulation for this position
 }
 
 type Order @entity {
-  id: Bytes! # markeetAddress:accountAddress:orderId
+  id: Bytes! # marketAddress:accountAddress:orderId
   position: Position! # Parent Position
   account: Account! # Account address (needed to query by account as position.marketAccount.account is not supported)
   market: Market! # Market address (needed to query by market as position.marketAccount.account is not supported)
@@ -119,7 +121,7 @@ type Order @entity {
   newLong: BigInt! # Position long size after settlement. Optimistically updated on Fulfillment if requested
   newShort: BigInt! # Position short size after settlement. Optimistically updated on Fulfillment if requested
   #
-  accumulation: AccountAccumulation! # Accumulation for this order
+  accumulation: MarketAccountAccumulation! # Accumulation for this order
   #
   transactionHashes: [Bytes!]! # Transaction hashes for this order's creation
 }
@@ -178,7 +180,7 @@ type MarketAccumulator @entity(immutable: true) {
 }
 
 # Accumulation data for an account order or position.
-type AccountAccumulation @entity {
+type MarketAccountAccumulation @entity {
   id: Bytes! # determined by creator
   collateral_accumulation: BigInt! # Total collateral accumulated for the parent entity - summation of collateral_subAccumulation_*
   fee_accumulation: BigInt! # Total fees accumulated for the parent entity - summation of fee_subAccumulation_*
@@ -234,6 +236,17 @@ type MarketAccumulation @entity {
   interestRateMaker: BigInt!
   interestRateLong: BigInt!
   interestRateShort: BigInt!
+}
+
+# TODO: Accumulation data for a MarketAccount, bucketed by time
+type AccountNewAccumulation @entity {
+  id: Bytes! # market:version
+  market: Market! # Parent Market
+  account: Account! # Parent Account
+  marketAccount: MarketAccount! # Parent MarketAccount
+  bucket: Bucket! # Bucket for this accumulation
+  timestamp: BigInt! # Oracle version timestamp
+  # TODO: determine metrics to add here
 }
 
 type MultiInvokerTriggerOrder @entity {

--- a/src/market.ts
+++ b/src/market.ts
@@ -776,9 +776,9 @@ export function fulfillOrder(order: OrderStore, price: BigInt, oracleVersionTime
     marketAccount,
     oracleVersionTimestamp,
     delta.isZero(),
-    position.maker,
-    position.long,
-    position.short,
+    order.maker.abs(),
+    order.long.abs(),
+    order.short.abs(),
     transformedPrice,
   )
 
@@ -1277,13 +1277,13 @@ function accumulateFulfilledOrder(
     if (!isDeltaNeutral) {
       marketAccountAccumulation.trades = marketAccountAccumulation.trades.plus(BigInt.fromU32(1))
     }
-    // Record absolute position, which was aggregated in fulfillOrder
-    marketAccountAccumulation.maker = maker
-    marketAccountAccumulation.long = long
-    marketAccountAccumulation.short = short
-    marketAccountAccumulation.makerNotional = notional(maker, price)
-    marketAccountAccumulation.longNotional = notional(long, price)
-    marketAccountAccumulation.shortNotional = notional(short, price)
+    // Record absolute position deltas
+    marketAccountAccumulation.maker = marketAccountAccumulation.maker.plus(maker)
+    marketAccountAccumulation.long = marketAccountAccumulation.long.plus(long)
+    marketAccountAccumulation.short = marketAccountAccumulation.short.plus(short)
+    marketAccountAccumulation.makerNotional = marketAccountAccumulation.makerNotional.plus(notional(maker, price))
+    marketAccountAccumulation.longNotional = marketAccountAccumulation.longNotional.plus(notional(long, price))
+    marketAccountAccumulation.shortNotional = marketAccountAccumulation.shortNotional.plus(notional(short, price))
 
     // Accumulate at Market
     const marketAccumulation = loadOrCreateMarketAccumulation(marketAccount.market, buckets[i], bucketTimestamp)

--- a/src/market.ts
+++ b/src/market.ts
@@ -948,8 +948,6 @@ function createMarketAccountPositionOrder(
     orderEntity.newLong = BigInt.zero()
     orderEntity.newShort = BigInt.zero()
 
-    orderEntity.accumulation = createMarketAccountAccumulation(entityId).id
-
     // If we are creating an oracle version here, it is unrequested because the request comes before the OrderCreated event
     const oracleVersionEntity = getOrCreateOracleVersion(subOracleAddress, oracleVersion, false, null)
     orderEntity.oracleVersion = oracleVersionEntity.id

--- a/src/market.ts
+++ b/src/market.ts
@@ -538,6 +538,7 @@ function handleOrderCreated(
 
   // Record the final collateral delta for the order
   order.collateral = order.collateral.plus(finalCollateralDelta)
+  order.endCollateral = order.startCollateral.plus(order.collateral)
   // If this is an order occurring at the start of a new position, add the collateral to the start collateral
   if (position.startVersion.equals(version))
     position.startCollateral = position.startCollateral.plus(finalCollateralDelta)
@@ -944,6 +945,7 @@ function createMarketAccountPositionOrder(
     orderEntity.short = BigInt.zero()
     orderEntity.collateral = BigInt.zero()
     orderEntity.startCollateral = newEntity_startCollateral
+    orderEntity.endCollateral = BigInt.zero()
     orderEntity.newMaker = BigInt.zero()
     orderEntity.newLong = BigInt.zero()
     orderEntity.newShort = BigInt.zero()

--- a/src/market.ts
+++ b/src/market.ts
@@ -775,7 +775,7 @@ export function fulfillOrder(order: OrderStore, price: BigInt, oracleVersionTime
   accumulateFulfilledOrder(
     marketAccount,
     oracleVersionTimestamp,
-    delta.gt(BigInt.zero()),
+    delta == BigInt.zero(),
     position.maker,
     position.long,
     position.short,
@@ -1264,7 +1264,7 @@ function createMarketAccountAccumulation(
 function accumulateFulfilledOrder(
   marketAccount: MarketAccountStore,
   oracleVersionTimestamp: BigInt,
-  isDeltaPositive: bool,
+  isDeltaNeutral: bool,
   maker: BigInt,
   long: BigInt,
   short: BigInt,
@@ -1276,7 +1276,7 @@ function accumulateFulfilledOrder(
 
     // Accumulate at MarketAccount
     const marketAccountAccumulation = loadOrCreateMarketAccountAccumulation(marketAccount, buckets[i], bucketTimestamp)
-    if (isDeltaPositive) {
+    if (!isDeltaNeutral) {
       marketAccountAccumulation.trades = marketAccountAccumulation.trades.plus(BigInt.fromU32(1))
     }
     // Record absolute position, which was aggregated in fulfillOrder
@@ -1291,7 +1291,7 @@ function accumulateFulfilledOrder(
     const marketAccumulation = loadOrCreateMarketAccumulation(marketAccount.market, buckets[i], bucketTimestamp)
     marketAccumulation.trades = marketAccumulation.trades.plus(BigInt.fromU32(1))
     // If this is the MarketAccount's first trade for the bucket, increment the number of traders
-    if (isDeltaPositive && marketAccountAccumulation.trades == BigInt.fromU32(1)) {
+    if (!isDeltaNeutral && marketAccountAccumulation.trades == BigInt.fromU32(1)) {
       marketAccumulation.traders = marketAccumulation.traders.plus(BigInt.fromU32(1))
     }
 

--- a/src/market.ts
+++ b/src/market.ts
@@ -951,6 +951,7 @@ function createMarketAccountPositionOrder(
     // If we are creating an oracle version here, it is unrequested because the request comes before the OrderCreated event
     const oracleVersionEntity = getOrCreateOracleVersion(subOracleAddress, oracleVersion, false, null)
     orderEntity.oracleVersion = oracleVersionEntity.id
+    orderEntity.timestamp = oracleVersionEntity.timestamp
     orderEntity.executionPrice = BigInt.zero()
 
     orderEntity.accumulation = createOrderAccumulation(

--- a/src/subOracle.ts
+++ b/src/subOracle.ts
@@ -44,7 +44,7 @@ function fulfillOracleVersion(subOracle: Bytes, version: BigInt, price: BigInt, 
     const orders = oracleVersion.orders.load()
     for (let i = 0; i < orders.length; i++) {
       // Propagate the fulfillment to the Order
-      fulfillOrder(orders[i], oracleVersion.price)
+      fulfillOrder(orders[i], oracleVersion.price, oracleVersion.timestamp)
     }
   }
 }

--- a/src/util/loadOrCreate.ts
+++ b/src/util/loadOrCreate.ts
@@ -75,6 +75,12 @@ export function loadOrCreateMarketAccountAccumulation(
     entity.timestamp = bucketTimestamp
     entity.collateral = BigInt.zero()
     entity.fees = BigInt.zero()
+    entity.maker = BigInt.zero()
+    entity.long = BigInt.zero()
+    entity.short = BigInt.zero()
+    entity.makerNotional = BigInt.zero()
+    entity.longNotional = BigInt.zero()
+    entity.shortNotional = BigInt.zero()
     entity.trades = BigInt.zero()
   }
   return entity

--- a/src/util/loadOrCreate.ts
+++ b/src/util/loadOrCreate.ts
@@ -1,0 +1,81 @@
+import { Bytes, BigInt, Address } from '@graphprotocol/graph-ts'
+import { IdSeparatorBytes } from './constants'
+import { bigIntToBytes } from '.'
+import {
+  MarketAccumulator as MarketAccumulatorStore,
+  MarketAccumulation as MarketAccumulationStore,
+  MarketAccountAccumulator as MarketAccountAccumulatorStore,
+  MarketAccountAccumulation as MarketAccountAccumulationStore,
+  MarketAccount,
+  Market,
+} from '../../generated/schema'
+
+export function loadOrCreateMarketAccumulation(
+  marketId: Bytes,
+  bucket: string,
+  bucketTimestamp: BigInt
+): MarketAccumulationStore {
+  const id = Bytes.fromUTF8(bucket)
+    .concat(IdSeparatorBytes)
+    .concat(marketId)
+    .concat(IdSeparatorBytes)
+    .concat(bigIntToBytes(bucketTimestamp))
+  let entity = MarketAccumulationStore.load(id)
+  if (!entity) {
+    entity = new MarketAccumulationStore(id)
+    entity.market = marketId
+    entity.bucket = bucket
+    entity.timestamp = bucketTimestamp
+    entity.maker = BigInt.zero()
+    entity.long = BigInt.zero()
+    entity.short = BigInt.zero()
+    entity.makerNotional = BigInt.zero()
+    entity.longNotional = BigInt.zero()
+    entity.shortNotional = BigInt.zero()
+    entity.pnlMaker = BigInt.zero()
+    entity.pnlLong = BigInt.zero()
+    entity.pnlShort = BigInt.zero()
+    entity.fundingMaker = BigInt.zero()
+    entity.fundingLong = BigInt.zero()
+    entity.fundingShort = BigInt.zero()
+    entity.interestMaker = BigInt.zero()
+    entity.interestLong = BigInt.zero()
+    entity.interestShort = BigInt.zero()
+    entity.positionFeeMaker = BigInt.zero()
+    entity.exposureMaker = BigInt.zero()
+    entity.fundingRateMaker = BigInt.zero()
+    entity.fundingRateLong = BigInt.zero()
+    entity.fundingRateShort = BigInt.zero()
+    entity.interestRateMaker = BigInt.zero()
+    entity.interestRateLong = BigInt.zero()
+    entity.interestRateShort = BigInt.zero()
+    entity.trades = BigInt.zero()
+    entity.traders = BigInt.zero()
+  }
+  return entity
+}
+
+export function loadOrCreateMarketAccountAccumulation(
+  marketAccount: MarketAccount,
+  bucket:string,
+  bucketTimestamp: BigInt
+): MarketAccountAccumulationStore {
+  const id = Bytes.fromUTF8(bucket)
+    .concat(IdSeparatorBytes)
+    .concat(marketAccount.id)
+    .concat(IdSeparatorBytes)
+    .concat(bigIntToBytes(bucketTimestamp))
+  let entity = MarketAccountAccumulationStore.load(id)
+  if (!entity) {
+    entity = new MarketAccountAccumulationStore(id)
+    entity.market = marketAccount.market
+    entity.account = marketAccount.account
+    entity.marketAccount = marketAccount.id
+    entity.bucket = bucket
+    entity.timestamp = bucketTimestamp
+    entity.collateral = BigInt.zero()
+    entity.fees = BigInt.zero()
+    entity.trades = BigInt.zero()
+  }
+  return entity
+}

--- a/src/util/loadOrThrow.ts
+++ b/src/util/loadOrThrow.ts
@@ -1,6 +1,6 @@
 import { Bytes } from '@graphprotocol/graph-ts'
 import {
-  AccountAccumulation,
+  MarketAccountAccumulation,
   Market,
   MarketAccount,
   MarketAccumulator,
@@ -13,9 +13,9 @@ import {
 
 // Helper Functions to Load or Throw Entities
 
-export function loadAccountAccumulation(id: Bytes): AccountAccumulation {
-  const entity = AccountAccumulation.load(id)
-  if (entity == null) throw new Error(`AccountAccumulation ${id.toHexString()}): not found`)
+export function loadMarketAccountAccumulation(id: Bytes): MarketAccountAccumulation {
+  const entity = MarketAccountAccumulation.load(id)
+  if (entity == null) throw new Error(`MarketAccountAccumulation ${id.toHexString()}): not found`)
   return entity
 }
 

--- a/src/util/loadOrThrow.ts
+++ b/src/util/loadOrThrow.ts
@@ -1,24 +1,19 @@
 import { Bytes } from '@graphprotocol/graph-ts'
 import {
-  MarketAccountAccumulation,
   Market,
   MarketAccount,
+  MarketAccountAccumulator,
   MarketAccumulator,
   MarketOrder,
   Oracle,
   OracleVersion,
   Order,
+  OrderAccumulation,
   Position,
-  AccountAccumulator,
 } from '../../generated/schema'
 
 // Helper Functions to Load or Throw Entities
 
-export function loadMarketAccountAccumulation(id: Bytes): MarketAccountAccumulation {
-  const entity = MarketAccountAccumulation.load(id)
-  if (entity == null) throw new Error(`MarketAccountAccumulation ${id.toHexString()}): not found`)
-  return entity
-}
 
 export function loadPosition(id: Bytes): Position {
   const entity = Position.load(id)
@@ -32,6 +27,11 @@ export function loadOrder(id: Bytes): Order {
   return entity
 }
 
+export function loadOrderAccumulation(id: Bytes): OrderAccumulation {
+  const entity = OrderAccumulation.load(id)
+  if (entity == null) throw new Error(`OrderAccumulation ${id.toHexString()}): not found`)
+  return entity
+}
 export function loadMarketOrder(id: Bytes): MarketOrder {
   const entity = MarketOrder.load(id)
   if (entity == null) throw new Error(`MarketOrder ${id.toHexString()}): not found`)
@@ -68,8 +68,8 @@ export function loadMarketAccumulator(id: Bytes): MarketAccumulator {
   return entity
 }
 
-export function loadAccountAccumulator(id: Bytes): AccountAccumulator {
-  const entity = AccountAccumulator.load(id)
-  if (entity == null) throw new Error(`AccountAccumulator ${id.toHexString()}): not found`)
+export function loadMarketAccountAccumulator(id: Bytes): MarketAccountAccumulator {
+  const entity = MarketAccountAccumulator.load(id)
+  if (entity == null) throw new Error(`MarketAccountAccumulator ${id.toHexString()}): not found`)
   return entity
 }

--- a/src/util/loadOrThrow.ts
+++ b/src/util/loadOrThrow.ts
@@ -9,6 +9,7 @@ import {
   OracleVersion,
   Order,
   Position,
+  AccountAccumulator,
 } from '../../generated/schema'
 
 // Helper Functions to Load or Throw Entities
@@ -64,5 +65,11 @@ export function loadOracleVersion(id: Bytes): OracleVersion {
 export function loadMarketAccumulator(id: Bytes): MarketAccumulator {
   const entity = MarketAccumulator.load(id)
   if (entity == null) throw new Error(`MarketAccumulator ${id.toHexString()}): not found`)
+  return entity
+}
+
+export function loadAccountAccumulator(id: Bytes): AccountAccumulator {
+  const entity = AccountAccumulator.load(id)
+  if (entity == null) throw new Error(`AccountAccumulator ${id.toHexString()}): not found`)
   return entity
 }


### PR DESCRIPTION
Just added collateral.  What other fields should we provide?

Doc states:
- Number of Trades
- Notional value
- Aggregated PNL Breakdown for all sides
- Aggregated PNL Breakdown per side (long/short/maker)
- PNL over time

To get the first, one could query all positions and count the orders for each.  Should we provide a `tradeCount` metric for this?

The other's I'm unsure how we wish to calculate.