### PR TITLE
Add {Market}AccountAccumulation data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perennial-v2",
-  "version": "2.0.0-rc22",
+  "version": "2.0.0-rc23",
   "license": "UNLICENSED",
   "scripts": {
     "codegen": "yarn clean && yarn combine && graph codegen",

--- a/schema.graphql
+++ b/schema.graphql
@@ -41,6 +41,7 @@ type MarketOrder @entity {
 type Account @entity {
   id: Bytes! # Address
   marketAccounts: [MarketAccount!]! @derivedFrom(field: "account") # Markets that this account has positions in
+  accumulations: [AccountAccumulation!]! @derivedFrom(field: "account") # List of bucketed account accumulations
 }
 
 type MarketAccount @entity {
@@ -66,8 +67,6 @@ type MarketAccount @entity {
   currentOrderId: BigInt! # Current account order id
   collateral: BigInt! # Current account collateral
   #
-  accumulators: [MarketAccountAccumulator!]!
-    @derivedFrom(field: "marketAccount") # Accumulates data for market and account across positions
   accumulations: [MarketAccountAccumulation!]!
     @derivedFrom(field: "marketAccount") # List of bucketed market account accumulations
 }
@@ -98,6 +97,8 @@ type Position @entity {
   netDeposits: BigInt! # Total deposits for this position
   #
   accumulation: OrderAccumulation! # Accumulation for this position
+  #
+  trades: BigInt! # Number of orders which changed this position
 }
 
 type Order @entity {
@@ -251,16 +252,6 @@ type MarketAccumulation @entity {
   traders: BigInt! # Number of accounts which changed their position
 }
 
-# Tracking value to provide pnl breakdowns. This is a cumulative value that is updated on each oracle version. To find the pnl for a given time period, subtract the previous version's value from the current version's value and multiply by the position.
-type MarketAccountAccumulator @entity(immutable: true) {
-  id: Bytes! # market:version
-  marketAccount: MarketAccount! # Parent MarketAccount
-  fromVersion: BigInt! # Oracle version timestamp
-  toVersion: BigInt! # Oracle version timestamp
-  collateral: BigInt! # Collateral accumulated
-  fees: BigInt! # Fees accumulated
-}
-
 # Accumulation data for a MarketAccount, bucketed by time
 type MarketAccountAccumulation @entity {
   id: Bytes! # market:version
@@ -269,15 +260,27 @@ type MarketAccountAccumulation @entity {
   marketAccount: MarketAccount! # Parent MarketAccount
   bucket: Bucket! # Bucket for this accumulation
   timestamp: BigInt! # Oracle version timestamp
-  collateral: BigInt!
-  fees: BigInt!
+  accumulation: OrderAccumulation! # PNL and Fee Accumulation values for this marketAccount
   maker: BigInt! # Latest maker position in bucket
   long: BigInt! # Latest long position in bucket
   short: BigInt! # Latest short position in bucket
   makerNotional: BigInt! # Notional value of maker position
   longNotional: BigInt! # Notional value of long position
   shortNotional: BigInt! # Notional value of short position
-  trades: BigInt! # Number of orders which increased the account's position
+  trades: BigInt! # Number of orders which modified the account's position
+}
+
+# Accumulation data for an Account, bucketed by time
+type AccountAccumulation @entity {
+  id: Bytes! # market:version
+  account: Account! # Parent Account
+  bucket: Bucket! # Bucket for this accumulation
+  timestamp: BigInt! # Oracle version timestamp
+  accumulation: OrderAccumulation! # PNL and Fee Accumulation values for this account
+  makerNotional: BigInt! # Notional value of maker position
+  longNotional: BigInt! # Notional value of long position
+  shortNotional: BigInt! # Notional value of short position
+  trades: BigInt! # Number of orders which modified the account's position
 }
 
 # Accumulation data for a protocol, bucketed by time

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -3,3 +3,4 @@ import { BigInt, Bytes } from '@graphprotocol/graph-ts'
 export const IdSeparatorBytes = Bytes.fromUTF8(':')
 export const ZeroAddress = Bytes.fromHexString('0x0000000000000000000000000000000000000000')
 export const SecondsPerYear = BigInt.fromI64(31536000)
+export const Buckets = ['hourly', 'daily', 'weekly', 'all']

--- a/src/util/loadOrThrow.ts
+++ b/src/util/loadOrThrow.ts
@@ -2,7 +2,6 @@ import { Bytes } from '@graphprotocol/graph-ts'
 import {
   Market,
   MarketAccount,
-  MarketAccountAccumulator,
   MarketAccumulator,
   MarketOrder,
   Oracle,
@@ -13,7 +12,6 @@ import {
 } from '../../generated/schema'
 
 // Helper Functions to Load or Throw Entities
-
 
 export function loadPosition(id: Bytes): Position {
   const entity = Position.load(id)
@@ -65,11 +63,5 @@ export function loadOracleVersion(id: Bytes): OracleVersion {
 export function loadMarketAccumulator(id: Bytes): MarketAccumulator {
   const entity = MarketAccumulator.load(id)
   if (entity == null) throw new Error(`MarketAccumulator ${id.toHexString()}): not found`)
-  return entity
-}
-
-export function loadMarketAccountAccumulator(id: Bytes): MarketAccountAccumulator {
-  const entity = MarketAccountAccumulator.load(id)
-  if (entity == null) throw new Error(`MarketAccountAccumulator ${id.toHexString()}): not found`)
   return entity
 }


### PR DESCRIPTION
Adds two new bucketed accumulations: `MarketAccountAccumulation` and `AccountAccumulation` which contain data about a MarketAccount and Account across different periods of time